### PR TITLE
setup.py fails due to reference to README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='me@lmorchard.com',
     url='http://github.com/lmorchard/django-badger',
     license='BSD',
-    packages=['badger', 'badger.management.commands', 'badger.migrations'],
+    packages=['badger', 'badger.management', 'badger.management.commands', 'badger.migrations'],
     package_data={'badger': ['fixtures/*', 'templates/badger/*.html', 'templates/badger/includes/*.html']},
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
Broken reference to README.md causes setup.py to fail.  Changed to README.rst to fix.

```
Downloading/unpacking django-badger from git+git://github.com/lmorchard/django-badger.git (from -r requirements.txt (line 52))
  Cloning git://github.com/lmorchard/django-badger.git to /Users/coryjohns/.virtualenvs/bidsite/build/django-badger
  Running setup.py egg_info for package django-badger
    Traceback (most recent call last):
      File "<string>", line 14, in <module>
      File "/Users/coryjohns/.virtualenvs/bidsite/build/django-badger/setup.py", line 8, in <module>
        long_description=open('README.md').read(),
    IOError: [Errno 2] No such file or directory: 'README.md'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 14, in <module>

  File "/Users/coryjohns/.virtualenvs/bidsite/build/django-badger/setup.py", line 8, in <module>

    long_description=open('README.md').read(),

IOError: [Errno 2] No such file or directory: 'README.md'
```
