### PR TITLE
Check for lack of django.utils.simplejson, to provide support for Django1.5

### DIFF
--- a/badger/models.py
+++ b/badger/models.py
@@ -20,14 +20,19 @@ from django.core.mail import send_mail
 from django.core.exceptions import ValidationError
 from django.core.files.storage import FileSystemStorage
 from django.core.files.base import ContentFile
-from django.core.serializers.json import DjangoJSONEncoder
-from django.utils import simplejson as json
 from django.contrib.auth.models import User, AnonymousUser
 from django.contrib.sites.models import Site
 from django.contrib.contenttypes.models import ContentType
 
 from django.template import Context, TemplateDoesNotExist
 from django.template.loader import render_to_string
+
+from django.core.serializers.json import DjangoJSONEncoder
+
+try:
+    import django.utils.simplejson as json
+except ImportError: # Django 1.5 no longer bundles simplejson
+    import json
 
 # HACK: Django 1.2 is missing receiver and user_logged_in
 try:


### PR DESCRIPTION
Django 1.5 no longer bundles simplejson in django.utils.  Core devs recommend using standard library json for Django 1.5, this change provides forward and backward compatibility with legacy and current Django versions.
