### PR TITLE
Fix #163 - Don't create multiple DeferredAwards for unique badges.

### DIFF
--- a/badger/models.py
+++ b/badger/models.py
@@ -537,6 +537,11 @@ class Badge(models.Model):
             if not qs:
                 # If there's no user for this email address, create a
                 # DeferredAward for future claiming.
+
+                if self.unique and DeferredAward.objects.filter(
+                    badge=self, email=email).exists():
+                    raise BadgeAlreadyAwardedException()
+
                 da = DeferredAward(badge=self, email=email)
                 da.save()
                 return da


### PR DESCRIPTION
I went with raising a BadgeAlreadyAwardedException because from my point of view (as the badge awarder) I don't care if the badge has been claimed or not yet.

Thoughts? r?
