### PR TITLE
Fix copyright and urls

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011, Mozilla
+Copyright (c) 2011-2013, Mozilla Foundation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,3 @@
 ## TODO
 
-See: https://github.com/lmorchard/django-badger/issues
+See: https://github.com/mozilla/django-badger/issues

--- a/badger/views.py
+++ b/badger/views.py
@@ -426,7 +426,7 @@ def awards_by_badge(request, slug):
 def staff_tools(request):
     """HACK: This page offers miscellaneous tools useful to event staff.
     Will go away in the future, addressed by:
-    https://github.com/lmorchard/django-badger/issues/35
+    https://github.com/mozilla/django-badger/issues/35
     """
     if not (request.user.is_staff or request.user.is_superuser):
         return HttpResponseForbidden()

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -8,9 +8,9 @@ Installation
 
 .. TODO
 
-- TBD, see `badg.us <https://github.com/lmorchard/badg.us>`_ for an example
+- TBD, see `badg.us <https://github.com/mozilla/badg.us>`_ for an example
   site setup
-- ``pip install git://github.com/lmorchard/django-badger.git#egg=django-badger``
+- ``pip install git://github.com/mozilla/django-badger.git#egg=django-badger``
 
 Configuration
 -------------

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description=open('README.rst').read(),
     author='Leslie Michael Orchard',
     author_email='me@lmorchard.com',
-    url='http://github.com/lmorchard/django-badger',
+    url='http://github.com/mozilla/django-badger',
     license='BSD',
     packages=['badger', 'badger.templatetags',  'badger.management', 'badger.management.commands', 'badger.migrations'],
     package_data={'badger': ['fixtures/*', 'templates/badger_playdoh/*.html', 'templates/badger_playdoh/includes/*.html', 'templates/badger_vanilla/*.html', 'templates/badger_vanilla/includes/*.html']},


### PR DESCRIPTION
Bunch of urls pointed to the old repository location. Fixed that.
Updated copyright to be Mozilla Foundation and have the correct
years.

r?
