### PR TITLE
Add MANIFEST.in; tweak setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,14 @@
+include LICENSE
+include MANIFEST.in
+include manage.py
+include README.rst
+include runtests.py
+include setup.py
+include test_settings.py
+include TODO.md
+
+recursive-include docs *.py *.rst Makefile
+
+recursive-include badger *.txt *.py *.png *.html *.json *.txt
+
+recursive-include badger_example *.html *.json *.txt

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from setuptools import setup
+from setuptools import find_packages, setup
 try:
     import multiprocessing
 except ImportError:
@@ -15,21 +15,21 @@ setup(
     author_email='me@lmorchard.com',
     url='http://github.com/mozilla/django-badger',
     license='BSD',
-    packages=['badger', 'badger.templatetags',  'badger.management', 'badger.management.commands', 'badger.migrations'],
-    package_data={'badger': ['fixtures/*', 'templates/badger_playdoh/*.html', 'templates/badger_playdoh/includes/*.html', 'templates/badger_vanilla/*.html', 'templates/badger_vanilla/includes/*.html']},
+    packages=find_packages(),
     include_package_data=True,
     classifiers=[
         'Development Status :: 4 - Beta',
-        # I don't know what exactly this means, but why not?
         'Framework :: Django',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires=[
-        'django>=1.2',
+        'django>=1.4',
         'PIL',
     ],
     tests_require=[


### PR DESCRIPTION
This cleans up setup.py a bit, makes sure it has some additional
metadata to help PyPI, makes sure everything that should be in an sdist
will be in the sdist and switches to use find_packages() in setuptools.

This is minor cleanup. Using find_packages() picks up badger.tests in addition to what was in setup.py previously. If you add new packages, then find_packages() will automatically pick them up--so it's less maintenance.

Adding the additional Python version specific Trove classifiers helps folks who are looking at PyPI metadata to find out who's holding out on Python 3. Plus it helps anyone who might install this know whether they have an appropriate Python version.

I updated the Django version to 1.4 since that's the oldest supported Django. We should tweak travis so it's testing the matrix of Python 2.6, 2.7, Django 1.4, Django 1.5. I'll look into that in a future PR.

You can use check-manifest to verify the MANIFEST.in catches everything. I skipped 

r?
