### PR TITLE
Fix badge image conversion issues

### DIFF
--- a/badger/models.py
+++ b/badger/models.py
@@ -158,7 +158,10 @@ def scale_image(img_upload, img_max_size):
         x_offset + int(crop_width), y_offset + int(crop_height)))
     img = img.resize((dst_width, dst_height), Image.ANTIALIAS)
 
-    if img.mode != "RGB":
+    # If the mode isn't RGB or RGBA we convert it. If it's not one
+    # of those modes, then we don't know what the alpha channel should
+    # be so we convert it to "RGB".
+    if img.mode not in ("RGB", "RGBA"):
         img = img.convert("RGB")
     new_img = StringIO()
     img.save(new_img, "PNG")


### PR DESCRIPTION
This fixes the problem where if you try to create a badge with a PNG
image that has an alpha channel, django-badger takes that alpha channel
out back and shoots it in the face with fire changing it to charcoal
black.

Quick r?
