### PR TITLE
Use Django's AUTH_USER_MODEL rather than the default User model

### DIFF
--- a/badger/feeds.py
+++ b/badger/feeds.py
@@ -9,7 +9,8 @@ from django.utils.feedgenerator import (SyndicationFeed, Rss201rev2Feed,
 import django.utils.simplejson as json
 from django.shortcuts import get_object_or_404
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
+User = get_user_model()
 from django.conf import settings
 
 try:

--- a/badger/models.py
+++ b/badger/models.py
@@ -21,7 +21,8 @@ from django.core.exceptions import ValidationError
 from django.core.files.storage import FileSystemStorage
 from django.core.files.base import ContentFile
 from django.contrib.auth.models import AnonymousUser
-User = settings.AUTH_USER_MODEL
+from django.contrib.auth import get_user_model
+User = get_user_model()
 
 from django.contrib.sites.models import Site
 from django.contrib.contenttypes.models import ContentType

--- a/badger/tests/__init__.py
+++ b/badger/tests/__init__.py
@@ -5,7 +5,8 @@ from contextlib import contextmanager
 from django.conf import settings
 from django.core.management import call_command
 from django.db.models import loading
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
+User = get_user_model()
 from django import test
 from django.utils.translation import get_language
 

--- a/badger/tests/test_badges_py.py
+++ b/badger/tests/test_badges_py.py
@@ -3,7 +3,8 @@ import logging
 from django.conf import settings
 from django.core.management import call_command
 from django.template.defaultfilters import slugify
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
+User = get_user_model()
 
 from nose.tools import assert_equal, with_setup, assert_false, eq_, ok_
 from nose.plugins.attrib import attr

--- a/badger/tests/test_feeds.py
+++ b/badger/tests/test_feeds.py
@@ -13,7 +13,8 @@ from nose.plugins.attrib import attr
 
 from django.template.defaultfilters import slugify
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
+User = get_user_model()
 
 try:
     from commons.urlresolvers import reverse

--- a/badger/tests/test_models.py
+++ b/badger/tests/test_models.py
@@ -32,7 +32,8 @@ try:
 except ImportError:
     from django.core.urlresolvers import reverse
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
+User = get_user_model()
 
 from . import BadgerTestCase, patch_settings
 

--- a/badger/tests/test_views.py
+++ b/badger/tests/test_views.py
@@ -9,7 +9,8 @@ from django.test.client import Client
 from django.utils import simplejson
 from django.utils.translation import get_language
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
+User = get_user_model()
 
 from pyquery import PyQuery as pq
 

--- a/badger/views.py
+++ b/badger/views.py
@@ -31,7 +31,8 @@ from django.views.decorators.http import (require_GET, require_POST,
 from django.contrib import messages
 
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
+User = get_user_model()
 
 try:
     import taggit


### PR DESCRIPTION
As referenced in the Django documentation: https://docs.djangoproject.com/en/dev/topics/auth/customizing/#auth-custom-user

Instead of referring to User directly, you should reference the user model using django.contrib.auth.get_user_model(). This method will return the currently active User model – the custom User model if one is specified, or User otherwise.

When you define a foreign key or many-to-many relations to the User model, you should specify the custom model using the AUTH_USER_MODEL setting. For example:
