### PR TITLE
Fix travis and tox config to always use latest django

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ python:
     - "2.7"
 
 env:
-    - DB=mysql DJANGO_VERSION=1.4.8
-    - DB=mysql DJANGO_VERSION=1.5.4
+    - DB=mysql DJANGO_VERSION=1.4
+    - DB=mysql DJANGO_VERSION=1.5
 
 before_install:
     - sudo apt-get update -qq
@@ -15,7 +15,7 @@ before_install:
     - sudo ln -s /usr/lib/`uname -i`-linux-gnu/libz.so /usr/lib
 
 install:
-    - pip install django==${DJANGO_VERSION}
+    - pip install --use-mirrors "Django>=${DJANGO_VERSION},<${DJANGO_VERSION}.99"
     - pip install -r requirements/dev.txt --use-mirrors
 
 script: python manage.py test -v2 badger

--- a/tox.ini
+++ b/tox.ini
@@ -3,29 +3,26 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
-[tox]
-envlist = py26_dj14, py27_dj14, py26_dj15, py27_dj15
-
 [testenv:py26_dj14]
 basepython = python2.6
-commands = pip install django<1.5
+commands = pip install "Django>=1.4,<1.4.99"
            pip install -r requirements/dev.txt
            {envpython} manage.py test -v2 badger
 
 [testenv:py27_dj14]
 basepython = python2.7
-commands = pip install django<1.5
+commands = pip install "Django>=1.4,<1.4.99"
            pip install -r requirements/dev.txt
            {envpython} manage.py test -v2 badger
 
 [testenv:py26_dj15]
 basepython = python2.6
-commands = pip install django<1.6
+commands = pip install "Django>=1.5,<1.5.99"
            pip install -r requirements/dev.txt
            {envpython} manage.py test -v2 badger
 
 [testenv:py27_dj15]
 basepython = python2.7
-commands = pip install django<1.6
+commands = pip install "Django>=1.5,<1.5.99"
            pip install -r requirements/dev.txt
            {envpython} manage.py test -v2 badger


### PR DESCRIPTION
This means we don't have to keep updating versions all the time which was getting old.

Quick r?
